### PR TITLE
Use 12 instead of 0, PM starts at 12, not 13

### DIFF
--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -186,9 +186,10 @@ formatF cb dt@(DT.DateTime d t) = case _ of
   Hours24 a →
     show (fromEnum $ T.hour t) <> cb a
   Hours12 a →
-    show ((fromEnum $ T.hour t) `mod` 12) <> cb a
+    let fix12 h = if h == 0 then 12 else h
+    in show (fix12 $ (fromEnum $ T.hour t) `mod` 12) <> cb a
   Meridiem a →
-    (if (fromEnum $ T.hour t) > 12 then "PM" else "AM") <> cb a
+    (if (fromEnum $ T.hour t) >= 12 then "PM" else "AM") <> cb a
   Minutes a →
     show (fromEnum $ T.minute t) <> cb a
   Seconds a →


### PR DESCRIPTION
I'm hoping the rules for 12 hour time are the same everywhere.. 
noon should be:
12:00 PM 
instead of:
00:00 AM