### PR TITLE
Update build for pursuit publishing, include README badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js:
-  - 6
+node_js: stable
 install:
-  - npm install pulp bower -g
-  - npm install && bower install
+  - npm install -g bower
+  - npm install
+  - bower install --production
 script:
-  - npm run test
+  - npm run -s build
+  - bower install
+  - npm run -s test
+after_success:
+- >-
+  test $TRAVIS_TAG &&
+  echo $GITHUB_TOKEN | pulp login &&
+  echo y | pulp publish --no-push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # purescript-formatters
-Replacement for numeral.js, moment.js etc
+
+[![Latest release](http://img.shields.io/github/release/slamdata/purescript-formatters.svg)](https://github.com/slamdata/purescript-formatters/releases)
+[![Build status](https://travis-ci.org/slamdata/purescript-formatters.svg?branch=master)](https://travis-ci.org/slamdata/purescript-formatters)
+
+A PureScript alternative to numeral.js, moment.js, etc.
+
+## Installation
+
+```
+bower install purescript-formatters
+```
 
 ## Number formatters
 
@@ -47,3 +57,7 @@ This is just subset of format/parse string from moment.js library. Currently sup
 + `mm`
 + `ss`
 + `SSS`
+
+## Documentation
+
+Module documentation is published on Pursuit: [http://pursuit.purescript.org/packages/purescript-formatters](http://pursuit.purescript.org/packages/purescript-formatters)

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,19 @@
 {
   "name": "purescript-formatters",
+  "homepage": "https://github.com/slamdata/purescript-formatters",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/slamdata/purescript-formatters.git"
+  },
   "ignore": [
     "**/.*",
-    "node_modules",
     "bower_components",
-    "output"
+    "node_modules",
+    "output",
+    "test",
+    "bower.json",
+    "package.json"
   ],
   "dependencies": {
     "purescript-prelude": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,14 @@
 {
-  "name": "purescript-formatters",
-  "description": "Replacement for numeral.js, moment.js etc",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/slamdata/purescript-formatters"
-  },
-  "contributors": [
-    "Maxim Zimaliev <zimaliev@gmail.com>"
-  ],
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/slamdata/purescript-formatters/issues"
-  },
+  "private": true,
   "scripts": {
-    "build": "pulp build -- --censor-lib --strict --stash",
-    "test": "pulp test -- --censor-lib --strict --stash"
+    "clean": "rimraf output && rimraf .pulp-cache",
+    "build": "pulp build -- --censor-lib --strict",
+    "test": "pulp test"
   },
-  "homepage": "https://github.com/slamdata/purescript-formatters#readme",
-  "dependencies": {
-    "pulp": "^9.1.0",
+  "devDependencies": {
+    "pulp": "^10.0.1",
     "purescript": "^0.10.7",
-    "purescript-psa": "^0.3.9"
+    "purescript-psa": "^0.4.0",
+    "rimraf": "^2.6.1"
   }
 }


### PR DESCRIPTION
I know we just did this :smile: but I noticed we don't (and can't, due to bower.json missing fields) publish to pursuit at the moment. So I just copied over the standard kind of build stuff we use elsewhere.