### PR TITLE
Zero-pad day fields in DayOfMonthTwoDigits

### DIFF
--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -185,7 +185,7 @@ formatF cb dt@(DT.DateTime d t) = case _ of
     let month = fromEnum $ D.month d
     in (padSingleDigit month) <> cb a
   DayOfMonthTwoDigits a →
-    show (fromEnum $ D.day d) <> cb a
+    (padSingleDigit $ fromEnum $ D.day d) <> cb a
   DayOfMonth a →
     show (fromEnum $ D.day d) <> cb a
   UnixTimestamp a →


### PR DESCRIPTION
fixes the issue when the date is single digit and it's not zero padded even though `DD` is being used in the formatter.