### PR TITLE
Add `MinutesTwoDigits` + `SecondsTwoDigits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ This is just subset of format/parse string from moment.js library. Currently sup
 + `ss`
 + `s`
 + `SSS`
++ `SS`
++ `S`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ This is just subset of format/parse string from moment.js library. Currently sup
 + `hh`
 + `a`
 + `mm`
++ `m`
 + `ss`
++ `s`
 + `SSS`
 
 ## Documentation

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -58,6 +58,8 @@ data FormatterF a
   | Seconds a
   | SecondsTwoDigits a
   | Milliseconds a
+  | MillisecondsShort a
+  | MillisecondsTwoDigits a
   | Placeholder String a
   | End
 
@@ -80,6 +82,8 @@ instance formatterFFunctor ∷ Functor FormatterF where
   map f (Seconds a) = Seconds $ f a
   map f (SecondsTwoDigits a) = SecondsTwoDigits $ f a
   map f (Milliseconds a) = Milliseconds $ f a
+  map f (MillisecondsShort a) = MillisecondsShort $ f a
+  map f (MillisecondsTwoDigits a) = MillisecondsTwoDigits $ f a
   map f (Placeholder str a) = Placeholder str $ f a
   map f End = End
 
@@ -108,6 +112,8 @@ printFormatterF cb = case _ of
   MinutesTwoDigits a → "mm" <> cb a
   Seconds a → "s" <> cb a
   SecondsTwoDigits a → "ss" <> cb a
+  MillisecondsShort a → "S" <> cb a
+  MillisecondsTwoDigits a → "SS" <> cb a
   Milliseconds a → "SSS" <> cb a
   Placeholder s a → s <> cb a
   End → ""
@@ -163,6 +169,8 @@ formatterFParser cb =
     , (PC.try $ PS.string "ss") *> map SecondsTwoDigits cb
     , (PC.try $ PS.string "s") *> map Seconds cb
     , (PC.try $ PS.string "SSS") *> map Milliseconds cb
+    , (PC.try $ PS.string "SS") *> map MillisecondsTwoDigits cb
+    , (PC.try $ PS.string "S") *> map MillisecondsShort cb
     , (Placeholder <$> placeholderContent <*> cb)
     , (PS.eof $> End)
     ]
@@ -216,7 +224,11 @@ formatF cb dt@(DT.DateTime d t) = case _ of
   SecondsTwoDigits a →
     (padSingleDigit <<< fromEnum $ T.second t) <> cb a
   Milliseconds a →
-    (padDoubleDigit $ fromEnum $ T.millisecond t) <> cb a
+    (padDoubleDigit <<< fromEnum $ T.millisecond t) <> cb a
+  MillisecondsShort a →
+    (show $ (_ / 100) $ fromEnum $ T.millisecond t) <> cb a
+  MillisecondsTwoDigits a →
+    (padSingleDigit $ (_ / 10) $ fromEnum $ T.millisecond t) <> cb a
   Placeholder s a →
     s <> cb a
   End → ""
@@ -423,6 +435,18 @@ unformatFParser cb = case _ of
     let sss = foldDigits ds
     when (Arr.length ds /= 3 || sss < 0 || sss > 999) $ P.fail "Incorrect millisecond"
     lift $ modify _{millisecond = Just sss}
+    cb a
+  MillisecondsShort a → do
+    ds ← some digit
+    let s = foldDigits ds
+    when (Arr.length ds /= 1 || s < 0 || s > 9) $ P.fail "Incorrect 1-digit millisecond"
+    lift $ modify _{millisecond = Just s}
+    cb a
+  MillisecondsTwoDigits a → do
+    ds ← some digit
+    let ss = foldDigits ds
+    when (Arr.length ds /= 2 || ss < 0 || ss > 99) $ P.fail "Incorrect 2-digit millisecond"
+    lift $ modify _{millisecond = Just ss}
     cb a
   Placeholder s a → do
     PS.string s

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -391,25 +391,25 @@ unformatFParser cb = case _ of
   MinutesTwoDigits a → do
     ds ← some digit
     let mm = foldDigits ds
-    when (Arr.length ds > 2 || mm < 0 || mm > 59) $ P.fail "Incorrect minute"
+    when (Arr.length ds /= 2 || mm < 0 || mm > 59) $ P.fail "Incorrect 2-digit minute"
     lift $ modify _{minute = Just mm}
     cb a
   Minutes a → do
     ds ← some digit
     let mm = foldDigits ds
-    when (mm < 0 || mm > 59) $ P.fail "Incorrect minute"
+    when (Arr.length ds > 2 || mm < 0 || mm > 59) $ P.fail "Incorrect minute"
     lift $ modify _{minute = Just mm}
     cb a
   SecondsTwoDigits a → do
     ds ← some digit
     let ss = foldDigits ds
-    when (Arr.length ds > 2 || ss < 0 || ss > 59) $ P.fail "Incorrect 2-digi second"
+    when (Arr.length ds /= 2 || ss < 0 || ss > 59) $ P.fail "Incorrect 2-digit second"
     lift $ modify _{second = Just ss}
     cb a
   Seconds a → do
     ds ← some digit
     let ss = foldDigits ds
-    when (Arr.length ds /= 2 || ss < 0 || ss > 59) $ P.fail "Incorrect second"
+    when (Arr.length ds > 2 || ss < 0 || ss > 59) $ P.fail "Incorrect second"
     lift $ modify _{second = Just ss}
     cb a
   Milliseconds a → do

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -216,7 +216,7 @@ formatF cb dt@(DT.DateTime d t) = case _ of
   SecondsTwoDigits a →
     (padSingleDigit <<< fromEnum $ T.second t) <> cb a
   Milliseconds a →
-    (padSingleDigit $ fromEnum $ T.millisecond t) <> cb a
+    (padDoubleDigit $ fromEnum $ T.millisecond t) <> cb a
   Placeholder s a →
     s <> cb a
   End → ""
@@ -224,6 +224,12 @@ formatF cb dt@(DT.DateTime d t) = case _ of
 padSingleDigit :: Int -> String
 padSingleDigit i
   | i < 10    = "0" <> (show i)
+  | otherwise = show i
+
+padDoubleDigit :: Int -> String
+padDoubleDigit i
+  | i < 100 && i > 10 = "0" <> (show i)
+  | i < 100 && i < 10 = "00" <> (show i)
   | otherwise = show i
 
 format ∷ Formatter → DT.DateTime → String

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -119,18 +119,18 @@ numeralTests = do
 
 -- April 12th 2017 at 11:34:34:234
 -- 4/12/2017
-makeDateTime ∷ Int -> Int -> Int -> DTi.DateTime
-makeDateTime year month day =
+makeDateTime ∷ Int -> Int -> Int -> Int -> Int -> Int -> Int -> DTi.DateTime
+makeDateTime year month day hour minute second millisecond =
   DTi.DateTime
     (D.canonicalDate (fromMaybe bottom $ toEnum year) (fromMaybe bottom $ toEnum month) (fromMaybe bottom $ toEnum day))
     (T.Time
-       (fromMaybe bottom $ toEnum 11)
-       (fromMaybe bottom $ toEnum 3)
-       (fromMaybe bottom $ toEnum 4)
-       (fromMaybe bottom $ toEnum 234))
+       (fromMaybe bottom $ toEnum hour)
+       (fromMaybe bottom $ toEnum minute)
+       (fromMaybe bottom $ toEnum second)
+       (fromMaybe bottom $ toEnum millisecond))
 
 testDateTime :: DTi.DateTime
-testDateTime = makeDateTime 2017 4 12
+testDateTime = makeDateTime 2017 4 12 11 3 4 234
 
 
 assert :: forall e. String -> String -> Boolean -> Tests e Unit
@@ -170,20 +170,23 @@ timeTest = do
   assertFormatting "April"           "MMMM" testDateTime
   assertFormatting "2017-12-04"      "YYYY-DD-MM" testDateTime
   assertFormatting "2017-Apr"        "YYYY-MMM" testDateTime
-  assertFormatting "Apr 1"           "MMM D" (makeDateTime 2017 4 1)
-  assertFormatting "Apr 01"          "MMM DD" (makeDateTime 2017 4 1)
+  assertFormatting "Apr 1"           "MMM D" (makeDateTime 2017 4 1 0 0 0 0)
+  assertFormatting "Apr 01"          "MMM DD" (makeDateTime 2017 4 1 0 0 0 0)
 
   -- This should probably be am (lowercase), if the desired
   -- functionality of the library is to mirror momentjs
-  assertFormatting "11:3:4:234 AM"     "hh:m:s:SSS a"  testDateTime
-  assertFormatting "11:03:04:234 AM"   "hh:mm:ss:SSS a"  testDateTime
+  assertFormatting "11:3:4 AM"      "hh:m:s a"  testDateTime
+  assertFormatting "11:03:04 AM"    "hh:mm:ss a"  testDateTime
+  assertFormatting "11:12:30.123"   "hh:mm:ss.SSS"  (makeDateTime 2017 4 10 11 12 30 123)
+  assertFormatting "11:12:30.023"   "hh:mm:ss.SSS"  (makeDateTime 2017 4 10 11 12 30 23)
+  assertFormatting "11:12:30.003"   "hh:mm:ss.SSS"  (makeDateTime 2017 4 10 11 12 30 3)
   assertFormatting "17"                "YY"  testDateTime
   log "  --- Format 20017 with YY"
-  assertFormatting "17"                "YY"  (makeDateTime 20017 4 12)
+  assertFormatting "17"                "YY"  (makeDateTime 20017 4 12 0 0 0 0)
   log "  --- Format 0 with YY"
-  assertFormatting "00"                "YY"  (makeDateTime 0 4 12)
+  assertFormatting "00"                "YY"  (makeDateTime 0 4 12 0 0 0 0)
   log "  --- Format -1 with YY"
-  assertFormatting "01"                "YY"  (makeDateTime (-1) 4 12)
+  assertFormatting "01"                "YY"  (makeDateTime (-1) 4 12 0 0 0 0)
 
   log "- Data.Formatter.DateTime.unformatDateTime "
 

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -180,6 +180,9 @@ timeTest = do
   assertFormatting "11:12:30.123"   "hh:mm:ss.SSS"  (makeDateTime 2017 4 10 11 12 30 123)
   assertFormatting "11:12:30.023"   "hh:mm:ss.SSS"  (makeDateTime 2017 4 10 11 12 30 23)
   assertFormatting "11:12:30.003"   "hh:mm:ss.SSS"  (makeDateTime 2017 4 10 11 12 30 3)
+  assertFormatting "11:12:30.12"    "hh:mm:ss.SS"  (makeDateTime 2017 4 10 11 12 30 123)
+  assertFormatting "11:12:30.1"     "hh:mm:ss.S"  (makeDateTime 2017 4 10 11 12 30 123)
+
   assertFormatting "17"                "YY"  testDateTime
   log "  --- Format 20017 with YY"
   assertFormatting "17"                "YY"  (makeDateTime 20017 4 12 0 0 0 0)

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -125,8 +125,8 @@ makeDateTime year month day =
     (D.canonicalDate (fromMaybe bottom $ toEnum year) (fromMaybe bottom $ toEnum month) (fromMaybe bottom $ toEnum day))
     (T.Time
        (fromMaybe bottom $ toEnum 11)
-       (fromMaybe bottom $ toEnum 34)
-       (fromMaybe bottom $ toEnum 34)
+       (fromMaybe bottom $ toEnum 3)
+       (fromMaybe bottom $ toEnum 4)
        (fromMaybe bottom $ toEnum 234))
 
 testDateTime :: DTi.DateTime
@@ -171,17 +171,19 @@ timeTest = do
   assertFormatting "2017-12-04"      "YYYY-DD-MM" testDateTime
   assertFormatting "2017-Apr"        "YYYY-MMM" testDateTime
   assertFormatting "Apr 1"           "MMM D" (makeDateTime 2017 4 1)
+  assertFormatting "Apr 01"          "MMM DD" (makeDateTime 2017 4 1)
 
   -- This should probably be am (lowercase), if the desired
   -- functionality of the library is to mirror momentjs
-  assertFormatting "11:34:34:234 AM" "hh:mm:ss:SSS a"  testDateTime
-  assertFormatting "17"            "YY"  testDateTime
+  assertFormatting "11:3:4:234 AM"     "hh:m:s:SSS a"  testDateTime
+  assertFormatting "11:03:04:234 AM"   "hh:mm:ss:SSS a"  testDateTime
+  assertFormatting "17"                "YY"  testDateTime
   log "  --- Format 20017 with YY"
-  assertFormatting "17"            "YY"  (makeDateTime 20017 4 12)
+  assertFormatting "17"                "YY"  (makeDateTime 20017 4 12)
   log "  --- Format 0 with YY"
-  assertFormatting "00"            "YY"  (makeDateTime 0 4 12)
+  assertFormatting "00"                "YY"  (makeDateTime 0 4 12)
   log "  --- Format -1 with YY"
-  assertFormatting "01"            "YY"  (makeDateTime (-1) 4 12)
+  assertFormatting "01"                "YY"  (makeDateTime (-1) 4 12)
 
   log "- Data.Formatter.DateTime.unformatDateTime "
 


### PR DESCRIPTION
To lead minutes and second with zeros if needed.

* Use `m` or `mm` pattern for formatting minutes
* Use `s` or `ss` pattern for formatting seconds
* Examples: 
    - `hh:m:s` -> `11:3:4`
    - `hh:mm:ss` -> `11:03:04`
* See https://momentjs.com/docs/#hour-minute-second-millisecond-and-offset-tokens