### PR TITLE
Fix `Hours24` to pad to two digits

### DIFF
--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -209,7 +209,7 @@ formatF cb dt@(DT.DateTime d t) = case _ of
   DayOfWeek a →
     show (fromEnum $ D.weekday d) <> cb a
   Hours24 a →
-    show (fromEnum $ T.hour t) <> cb a
+    padSingleDigit (fromEnum $ T.hour t) <> cb a
   Hours12 a →
     let fix12 h = if h == 0 then 12 else h
     in (padSingleDigit $ fix12 $ (fromEnum $ T.hour t) `mod` 12) <> cb a


### PR DESCRIPTION
@cryogenian I discovered yet another bug in the variables card that'll need this to fix it... sorry to bother you in the evening / weekend, but could you take a look? I don't think we need an `Hours24TwoDigit`, as currently `Hours12` auto-pads to two digits, so it seems this should for consistency (plus the pattern for it is `HH`, so...).