### PR TITLE
Add weekday name format for DateTimes

### DIFF
--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -58,6 +58,7 @@ data FormatterCommand
   | UnixTimestamp
   | DayOfWeek
   | DayOfWeekName
+  | DayOfWeekNameShort
   | Hours24
   | Hours12
   | Meridiem
@@ -90,7 +91,8 @@ printFormatterCommand = case _ of
   DayOfMonth → "D"
   UnixTimestamp → "X"
   DayOfWeek → "E"
-  DayOfWeekName → "A"
+  DayOfWeekName → "AA"
+  DayOfWeekNameShort → "A"
   Hours24 → "HH"
   Hours12 → "hh"
   Meridiem → "a"
@@ -127,7 +129,8 @@ formatterCommandParser = (PC.try <<< PS.string) `oneOfAs`
   , Tuple "DD" DayOfMonthTwoDigits
   , Tuple "D" DayOfMonth
   , Tuple "E" DayOfWeek
-  , Tuple "A" DayOfWeekName
+  , Tuple "AA" DayOfWeekName
+  , Tuple "A" DayOfWeekNameShort
   , Tuple "HH" Hours24
   , Tuple "hh" Hours12
   , Tuple "a" Meridiem
@@ -171,6 +174,7 @@ formatCommand dt@(DT.DateTime d t) = case _ of
   UnixTimestamp → show $ Int.floor $ (_ / 1000.0) $ unwrap $ unInstant $ fromDateTime dt
   DayOfWeek → show $ fromEnum $ D.weekday d
   DayOfWeekName → show $ D.weekday d
+  DayOfWeekNameShort → Str.take 3 $ show $ D.weekday d
   Hours24 → padSingleDigit (fromEnum $ T.hour t)
   Hours12 → padSingleDigit $ fix12 $ (fromEnum $ T.hour t) `mod` 12
   Meridiem → if (fromEnum $ T.hour t) >= 12 then "PM" else "AM"
@@ -362,6 +366,8 @@ unformatCommandParser = case _ of
   DayOfWeek → void $ parseInt 1 (validateRange 1 7) "Incorrect day of week"
   DayOfWeekName → _{day = _} `modifyWithParser`
     (fromEnum <$> parseDayOfWeekName)
+  DayOfWeekNameShort → _{day = _} `modifyWithParser`
+    (fromEnum <$> parseDayOfWeekNameShort)
   Hours24 → _{hour = _} `modifyWithParser`
     (parseInt 2 (validateRange 0 24 <> exactLength) "Incorrect 24 hour")
   Hours12 → _{hour = _} `modifyWithParser`
@@ -421,6 +427,17 @@ parseDayOfWeekName = (PC.try <<< PS.string) `oneOfAs`
   , Tuple "Friday" D.Friday
   , Tuple "Saturday" D.Saturday
   , Tuple "Sunday" D.Sunday
+  ]
+
+parseDayOfWeekNameShort ∷ ∀ m. Monad m ⇒ P.ParserT String m D.Weekday
+parseDayOfWeekNameShort = (PC.try <<< PS.string) `oneOfAs`
+  [ Tuple "Mon" D.Monday
+  , Tuple "Tue" D.Tuesday
+  , Tuple "Wed" D.Wednesday
+  , Tuple "Thu" D.Thursday
+  , Tuple "Fri" D.Friday
+  , Tuple "Sat" D.Saturday
+  , Tuple "Sun" D.Sunday
   ]
 
 parseMonth ∷ ∀ m. Monad m ⇒ P.ParserT String m D.Month

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -57,6 +57,7 @@ data FormatterCommand
   | DayOfMonth
   | UnixTimestamp
   | DayOfWeek
+  | DayOfWeekName
   | Hours24
   | Hours12
   | Meridiem
@@ -89,6 +90,7 @@ printFormatterCommand = case _ of
   DayOfMonth → "D"
   UnixTimestamp → "X"
   DayOfWeek → "E"
+  DayOfWeekName → "A"
   Hours24 → "HH"
   Hours12 → "hh"
   Meridiem → "a"
@@ -125,6 +127,7 @@ formatterCommandParser = (PC.try <<< PS.string) `oneOfAs`
   , Tuple "DD" DayOfMonthTwoDigits
   , Tuple "D" DayOfMonth
   , Tuple "E" DayOfWeek
+  , Tuple "A" DayOfWeekName
   , Tuple "HH" Hours24
   , Tuple "hh" Hours12
   , Tuple "a" Meridiem
@@ -167,6 +170,7 @@ formatCommand dt@(DT.DateTime d t) = case _ of
   DayOfMonth → show $ fromEnum $ D.day d
   UnixTimestamp → show $ Int.floor $ (_ / 1000.0) $ unwrap $ unInstant $ fromDateTime dt
   DayOfWeek → show $ fromEnum $ D.weekday d
+  DayOfWeekName → show $ D.weekday d
   Hours24 → padSingleDigit (fromEnum $ T.hour t)
   Hours12 → padSingleDigit $ fix12 $ (fromEnum $ T.hour t) `mod` 12
   Meridiem → if (fromEnum $ T.hour t) >= 12 then "PM" else "AM"
@@ -356,6 +360,8 @@ unformatCommandParser = case _ of
         }
   -- TODO we would need to use this value if we support date format using week number
   DayOfWeek → void $ parseInt 1 (validateRange 1 7) "Incorrect day of week"
+  DayOfWeekName → _{day = _} `modifyWithParser`
+    (fromEnum <$> parseDayOfWeekName)
   Hours24 → _{hour = _} `modifyWithParser`
     (parseInt 2 (validateRange 0 24 <> exactLength) "Incorrect 24 hour")
   Hours12 → _{hour = _} `modifyWithParser`
@@ -403,6 +409,18 @@ parseMeridiem =  (PC.try <<< PS.string) `oneOfAs`
   , Tuple "AM" AM
   , Tuple "pm" PM
   , Tuple "PM" PM
+  ]
+
+
+parseDayOfWeekName ∷ ∀ m. Monad m ⇒ P.ParserT String m D.Weekday
+parseDayOfWeekName = (PC.try <<< PS.string) `oneOfAs`
+  [ Tuple "Monday" D.Monday
+  , Tuple "Tuesday" D.Tuesday
+  , Tuple "Wednesday" D.Wednesday
+  , Tuple "Thursday" D.Thursday
+  , Tuple "Friday" D.Friday
+  , Tuple "Saturday" D.Saturday
+  , Tuple "Sunday" D.Sunday
   ]
 
 parseMonth ∷ ∀ m. Monad m ⇒ P.ParserT String m D.Month

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -91,8 +91,8 @@ printFormatterCommand = case _ of
   DayOfMonth → "D"
   UnixTimestamp → "X"
   DayOfWeek → "E"
-  DayOfWeekName → "AA"
-  DayOfWeekNameShort → "A"
+  DayOfWeekName → "dddd"
+  DayOfWeekNameShort → "ddd"
   Hours24 → "HH"
   Hours12 → "hh"
   Meridiem → "a"
@@ -129,8 +129,8 @@ formatterCommandParser = (PC.try <<< PS.string) `oneOfAs`
   , Tuple "DD" DayOfMonthTwoDigits
   , Tuple "D" DayOfMonth
   , Tuple "E" DayOfWeek
-  , Tuple "AA" DayOfWeekName
-  , Tuple "A" DayOfWeekNameShort
+  , Tuple "dddd" DayOfWeekName
+  , Tuple "ddd" DayOfWeekNameShort
   , Tuple "HH" Hours24
   , Tuple "hh" Hours12
   , Tuple "a" Meridiem

--- a/test/src/DateTime.purs
+++ b/test/src/DateTime.purs
@@ -22,8 +22,8 @@ datetimeTest = describe "Data.Formatter.DateTime" do
     , { format: "YYYY-DD-MM", dateStr: "2017-12-04" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YYYY-MMM", dateStr: "2017-Apr" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "MMM D", dateStr: "Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
-    , { format: "AA, MMM D", dateStr: "Saturday, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
-    , { format: "A, MMM D", dateStr: "Sat, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
+    , { format: "dddd, MMM D", dateStr: "Saturday, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
+    , { format: "ddd, MMM D", dateStr: "Sat, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
     , { format: "hh:mm:ss:SSS a", dateStr: "11:03:04:234 AM" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YY", dateStr: "17" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YY", dateStr: "17" , date: makeDateTime 20017 4 12 0 0 0 0} -- Format 20017 with YY

--- a/test/src/DateTime.purs
+++ b/test/src/DateTime.purs
@@ -22,7 +22,8 @@ datetimeTest = describe "Data.Formatter.DateTime" do
     , { format: "YYYY-DD-MM", dateStr: "2017-12-04" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YYYY-MMM", dateStr: "2017-Apr" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "MMM D", dateStr: "Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
-    , { format: "A, MMM D", dateStr: "Saturday, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
+    , { format: "AA, MMM D", dateStr: "Saturday, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
+    , { format: "A, MMM D", dateStr: "Sat, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
     , { format: "hh:mm:ss:SSS a", dateStr: "11:03:04:234 AM" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YY", dateStr: "17" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YY", dateStr: "17" , date: makeDateTime 20017 4 12 0 0 0 0} -- Format 20017 with YY

--- a/test/src/DateTime.purs
+++ b/test/src/DateTime.purs
@@ -22,6 +22,7 @@ datetimeTest = describe "Data.Formatter.DateTime" do
     , { format: "YYYY-DD-MM", dateStr: "2017-12-04" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YYYY-MMM", dateStr: "2017-Apr" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "MMM D", dateStr: "Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
+    , { format: "A, MMM D", dateStr: "Saturday, Apr 1" , date: makeDateTime 2017 4 1 0 0 0 0}
     , { format: "hh:mm:ss:SSS a", dateStr: "11:03:04:234 AM" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YY", dateStr: "17" , date: makeDateTime 2017 4 12 11 3 4 234}
     , { format: "YY", dateStr: "17" , date: makeDateTime 20017 4 12 0 0 0 0} -- Format 20017 with YY


### PR DESCRIPTION
I wanted a weekday name rather than the index. These changes allow a format string such as `"AA, MMM D"` and return something like "Sunday, April 1". (`"A"` for `"Sun"`)

Let me know if I missed something already in place to handle this formatting!
