### PR TITLE
added Datetime format dddd

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This is just subset of format/parse string from moment.js library. Currently sup
 + `MM`
 + `DD`
 + `D`
++ `dddd`
 + `X`
 + `E`
 + `HH`

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -56,7 +56,7 @@ data FormatterCommand
   | DayOfMonthTwoDigits
   | DayOfMonth
   | UnixTimestamp
-  | DayOfWeek
+  | DayOfWeekISO
   | Hours24
   | Hours12
   | Meridiem
@@ -88,7 +88,7 @@ printFormatterCommand = case _ of
   DayOfMonthTwoDigits → "DD"
   DayOfMonth → "D"
   UnixTimestamp → "X"
-  DayOfWeek → "E"
+  DayOfWeekISO → "E"
   Hours24 → "HH"
   Hours12 → "hh"
   Meridiem → "a"
@@ -124,7 +124,7 @@ formatterCommandParser = (PC.try <<< PS.string) `oneOfAs`
   , Tuple "MM" MonthTwoDigits
   , Tuple "DD" DayOfMonthTwoDigits
   , Tuple "D" DayOfMonth
-  , Tuple "E" DayOfWeek
+  , Tuple "E" DayOfWeekISO
   , Tuple "HH" Hours24
   , Tuple "hh" Hours12
   , Tuple "a" Meridiem
@@ -166,7 +166,7 @@ formatCommand dt@(DT.DateTime d t) = case _ of
   DayOfMonthTwoDigits → padSingleDigit $ fromEnum $ D.day d
   DayOfMonth → show $ fromEnum $ D.day d
   UnixTimestamp → show $ Int.floor $ (_ / 1000.0) $ unwrap $ unInstant $ fromDateTime dt
-  DayOfWeek → show $ fromEnum $ D.weekday d
+  DayOfWeekISO → show $ fromEnum $ D.weekday d
   Hours24 → padSingleDigit (fromEnum $ T.hour t)
   Hours12 → padSingleDigit $ fix12 $ (fromEnum $ T.hour t) `mod` 12
   Meridiem → if (fromEnum $ T.hour t) >= 12 then "PM" else "AM"
@@ -355,7 +355,7 @@ unformatCommandParser = case _ of
         , meridiem: Nothing
         }
   -- TODO we would need to use this value if we support date format using week number
-  DayOfWeek → void $ parseInt 1 (validateRange 1 7) "Incorrect day of week"
+  DayOfWeekISO → void $ parseInt 1 (validateRange 1 7) "Incorrect day of week"
   Hours24 → _{hour = _} `modifyWithParser`
     (parseInt 2 (validateRange 0 24 <> exactLength) "Incorrect 24 hour")
   Hours12 → _{hour = _} `modifyWithParser`

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -22,7 +22,6 @@ import Control.Monad.Reader.Trans (ReaderT, runReaderT, ask)
 import Control.Monad.State (State, modify, put, runState)
 import Control.Monad.Trans.Class (lift)
 import Data.Array as Array
-import Data.Date (Weekday(..))
 import Data.Date as D
 import Data.DateTime as DT
 import Data.DateTime.Instant (instant, toDateTime, fromDateTime, unInstant)
@@ -466,4 +465,5 @@ parseDayOfWeekFullName = (PC.try <<< PS.string) `oneOfAs` map (\day → Tuple (s
   , D.Thursday
   , D.Friday
   , D.Saturday
-  , D.Sunday ]
+  , D.Sunday
+  ]

--- a/test/src/DateTime.purs
+++ b/test/src/DateTime.purs
@@ -44,6 +44,7 @@ datetimeTest = describe "Data.Formatter.DateTime" do
     , { format: "hhmmssS", dateStr: "1112301", date: makeDateTime 2017 4 10 11 12 30 123 }
     , { format: "HHmmssSSS", dateStr: "134530123", date: makeDateTime 2017 4 10 13 45 30 123 }
     , { format: "HHmm", dateStr: "1345", date: makeDateTime 2017 4 10 13 45 30 123 }
+    , { format: "dddd", dateStr: "Saturday", date: makeDateTime 2017 9 9 13 45 30 123 }
     ]
     (\({ format, dateStr, date }) → do
       (format `FDT.formatDateTime` date) `shouldEqual` (Right dateStr)


### PR DESCRIPTION
I wanted to print the full name of the month, which this library currently does not support, and therefore implemented that format. Feedback welcome!