### PR TITLE
Moment.js-style escaping of literal text in date/time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This is just subset of format/parse string from moment.js library. Currently sup
 + `SS`
 + `S`
 
+Literal text can be escaped by enclosing it with square brackets: `[Today is] MMM D`
+
 ## Documentation
 
 Module documentation is published on Pursuit: [http://pursuit.purescript.org/packages/purescript-formatters](http://pursuit.purescript.org/packages/purescript-formatters)

--- a/test/src/DateTime.purs
+++ b/test/src/DateTime.purs
@@ -46,6 +46,7 @@ datetimeTest = describe "Data.Formatter.DateTime" do
     , { format: "hhmmssS", dateStr: "1112301", date: makeDateTime 2017 4 10 11 12 30 123 }
     , { format: "HHmmssSSS", dateStr: "134530123", date: makeDateTime 2017 4 10 13 45 30 123 }
     , { format: "HHmm", dateStr: "1345", date: makeDateTime 2017 4 10 13 45 30 123 }
+    , { format: "[It's] MMMM D[st]", dateStr: "It's April 1st" , date: makeDateTime 2017 4 1 0 0 0 0}
     ]
     (\({ format, dateStr, date }) → do
       (format `FDT.formatDateTime` date) `shouldEqual` (Right dateStr)


### PR DESCRIPTION
See https://github.com/moment/momentjs.com/blob/master/docs/moment/04-displaying/01-format.md#escaping-characters

P.S.: If anyone knows a neater way to construct a parser for this, I'd be happy to learn about it.