### PR TITLE
Update for compiler 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,11 @@
   "dependencies": {
     "purescript-parsing": "https://github.com/joncfoo/purescript-parsing.git#update-for-0.12.0",
     "purescript-fixed-points": "^5.0.0",
-    "purescript-datetime": "^v4.0.0"
+    "purescript-datetime": "^v4.0.0",
+    "purescript-generics-rep": "^6.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-lists": "^5.0.0",
+    "purescript-prelude": "^4.0.1"
   },
   "devDependencies": {
     "purescript-aff": "^5.0.0",

--- a/bower.json
+++ b/bower.json
@@ -16,19 +16,19 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-parsing": "^4.2.1",
-    "purescript-fixed-points": "^4.0.0",
-    "purescript-datetime": "^v3.3.0",
-    "purescript-transformers": "^3.4.0",
-    "purescript-lists": "^4.3.0",
-    "purescript-generics-rep": "^5.0.0"
+    "purescript-prelude": "^4.0.1",
+    "purescript-parsing": "https://github.com/justinwoo/purescript-parsing.git",
+    "purescript-fixed-points": "^5.0.0",
+    "purescript-datetime": "^v4.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-lists": "^5.0.0",
+    "purescript-generics-rep": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-aff": "^3.0.0",
-    "purescript-console": "^3.0.0",
-    "purescript-psci-support": "^3.0.0",
-    "purescript-spec": "^0.14.0"
+    "purescript-aff": "^5.0.0",
+    "purescript-console": "^4.1.0",
+    "purescript-psci-support": "^4.0.0",
+    "purescript-spec": "^3.0.0"
   },
   "resolutions": {
     "purescript-datetime": "interval"

--- a/bower.json
+++ b/bower.json
@@ -16,13 +16,13 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-parsing": "https://github.com/joncfoo/purescript-parsing.git#update-for-0.12.0",
     "purescript-fixed-points": "^5.0.0",
     "purescript-datetime": "^v4.0.0",
     "purescript-generics-rep": "^6.0.0",
     "purescript-transformers": "^4.1.0",
     "purescript-lists": "^5.0.0",
-    "purescript-prelude": "^4.0.1"
+    "purescript-prelude": "^4.0.1",
+    "purescript-parsing": "^5.0.0"
   },
   "devDependencies": {
     "purescript-aff": "^5.0.0",

--- a/bower.json
+++ b/bower.json
@@ -16,21 +16,14 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.0.1",
-    "purescript-parsing": "https://github.com/justinwoo/purescript-parsing.git",
+    "purescript-parsing": "https://github.com/joncfoo/purescript-parsing.git#update-for-0.12.0",
     "purescript-fixed-points": "^5.0.0",
-    "purescript-datetime": "^v4.0.0",
-    "purescript-transformers": "^4.1.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-generics-rep": "^6.0.0"
+    "purescript-datetime": "^v4.0.0"
   },
   "devDependencies": {
     "purescript-aff": "^5.0.0",
     "purescript-console": "^4.1.0",
     "purescript-psci-support": "^4.0.0",
     "purescript-spec": "^3.0.0"
-  },
-  "resolutions": {
-    "purescript-datetime": "interval"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript": "^0.11.0",
-    "purescript-psa": "^0.5.0",
-    "rimraf": "^2.6.1"
+    "pulp": "^12.3.0",
+    "purescript": "^0.12.0",
+    "purescript-psa": "^0.6.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -19,7 +19,7 @@ import Control.Alternative (class Alternative)
 import Control.Apply (applySecond, lift2)
 import Control.Lazy as Z
 import Control.Monad.Reader.Trans (ReaderT, runReaderT, ask)
-import Control.Monad.State (State, modify, put, runState)
+import Control.Monad.State (State, modify_, put, runState)
 import Control.Monad.Trans.Class (lift)
 import Data.Array as Array
 import Data.Date as D
@@ -39,6 +39,7 @@ import Data.Maybe (Maybe(..), maybe, fromMaybe)
 import Data.Newtype (unwrap)
 import Data.Ord (abs)
 import Data.String as Str
+import Data.String.CodeUnits as CU
 import Data.Time as T
 import Data.Time.Duration as Dur
 import Data.Tuple (Tuple(..))
@@ -113,10 +114,10 @@ parseFormatString = runP formatParser
 
 placeholderContent ∷ P.Parser String String
 placeholderContent =
-  Str.toCharArray "YMDEHhamsS"
+  CU.toCharArray "YMDEHhamsS"
   # PS.noneOf
   # Array.some
-  <#> Str.fromCharArray
+  <#> CU.fromCharArray
 
 formatterCommandParser ∷ P.Parser String FormatterCommand
 formatterCommandParser = (PC.try <<< PS.string) `oneOfAs`
@@ -393,7 +394,7 @@ unformatCommandParser = case _ of
   modifyWithParser ∷ ∀ s' s x. (s → Maybe x → s) → P.ParserT s' (State s) x → P.ParserT s' (State s) Unit
   modifyWithParser f p = do
     v ← p
-    lift $ modify (flip f (Just v))
+    lift $ modify_ (flip f (Just v))
 
 unformatParser ∷ ∀ m. Monad m ⇒ Formatter → P.ParserT String m DT.DateTime
 unformatParser f = do

--- a/src/Data/Formatter/Internal.purs
+++ b/src/Data/Formatter/Internal.purs
@@ -3,7 +3,6 @@ module Data.Formatter.Internal where
 import Prelude
 
 import Data.Foldable (class Foldable, foldl)
-import Data.Monoid (class Monoid, mempty)
 
 foldDigits ∷ ∀ f. Foldable f ⇒ f Int → Int
 foldDigits = foldl (\acc d → acc * 10 + d) zero

--- a/src/Data/Formatter/Interval.purs
+++ b/src/Data/Formatter/Interval.purs
@@ -18,7 +18,6 @@ import Data.Interval as I
 import Data.Interval.Duration.Iso (IsoDuration, unIsoDuration)
 import Data.Map (lookup)
 import Data.Maybe (maybe)
-import Data.Monoid (mempty)
 import Data.Tuple (Tuple(..))
 
 formatRecurringInterval ∷ I.RecurringInterval IsoDuration DateTime → String

--- a/src/Data/Formatter/Number.purs
+++ b/src/Data/Formatter/Number.purs
@@ -22,6 +22,7 @@ import Data.Traversable (for)
 import Data.Either (Either, either)
 import Data.Int as Int
 import Data.String as Str
+import Data.String.CodeUnits as CU
 
 import Data.Formatter.Parser.Utils (runP)
 import Data.Formatter.Internal (foldDigits, repeat)
@@ -123,17 +124,17 @@ format (Formatter f) num =
          roundedWithZeros =
            let roundedString = show rounded
                roundedLength = Str.length roundedString
-               zeros = repeat "0" (f.after - roundedLength)
-           in zeros <> roundedString
+               zeros' = repeat "0" (f.after - roundedLength)
+           in zeros' <> roundedString
          shownNumber =
            if f.comma
              then
-             addCommas [] zero $ Arr.reverse $ Str.toCharArray (repeat "0" zeros <> show integer)
+             addCommas [] zero $ Arr.reverse $ CU.toCharArray (repeat "0" zeros <> show integer)
              else repeat "0" zeros <> show integer
 
          addCommas ∷ Array Char → Int → Array Char → String
          addCommas acc counter input = case Arr.uncons input of
-           Nothing → Str.fromCharArray acc
+           Nothing → CU.fromCharArray acc
            Just {head, tail} | counter < 3 →
              addCommas (Arr.cons head acc) (counter + one) tail
            _ →
@@ -238,5 +239,5 @@ unformatNumber pattern str =
 -- good way to extract number back to show.
 formatOrShowNumber ∷ String → Number → String
 formatOrShowNumber patter number =
-  either (const $ show number) id
+  either (const $ show number) identity
   $ formatNumber patter number

--- a/src/Data/Formatter/Parser/Interval.purs
+++ b/src/Data/Formatter/Parser/Interval.purs
@@ -17,7 +17,6 @@ import Data.Formatter.Parser.Number (parseNumber, parseMaybeInteger)
 import Data.Interval as I
 import Data.Interval.Duration.Iso (IsoDuration, mkIsoDuration, prettyError)
 import Data.Maybe (Maybe)
-import Data.Monoid (class Monoid, mempty)
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple(..), snd)
 import Partial.Unsafe (unsafePartial)

--- a/test/src/DateTime.purs
+++ b/test/src/DateTime.purs
@@ -12,7 +12,7 @@ import Test.Spec (describe, Spec, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Utils (forAll, makeDateTime)
 
-datetimeTest ∷ ∀ e. Spec e Unit
+datetimeTest ∷ Spec Unit
 datetimeTest = describe "Data.Formatter.DateTime" do
   forAll (\a → a.format <> " | " <> a.dateStr)
     "formatDateTime/unformatDateTime should format/unformat dateTime"

--- a/test/src/Interval.purs
+++ b/test/src/Interval.purs
@@ -2,7 +2,7 @@ module Test.Interval (intervalTest) where
 
 import Prelude
 
-import Control.Monad.Aff (Aff)
+import Effect.Aff (Aff)
 import Data.DateTime (DateTime)
 import Data.Either (Either(..), fromRight)
 import Data.Foldable (class Foldable, fold)
@@ -17,10 +17,10 @@ import Test.Spec (describe, Spec)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Utils (forAll, makeDateTime)
 
-prop ∷ ∀ e e' f. Foldable f ⇒ String → f {str ∷ String | e'} → ({str ∷ String | e'} → Aff e Unit) → Spec e Unit
+prop ∷ ∀ e f. Foldable f ⇒ String → f {str ∷ String | e} → ({str ∷ String | e} → Aff Unit) → Spec Unit
 prop = forAll (show <<< _.str)
 
-intervalTest ∷ ∀ e. Spec e Unit
+intervalTest ∷ Spec Unit
 intervalTest = describe "Data.Formatter.Interval" do
   prop "shouldn't unformat invalid Interval" invalidIntervals \({str, err}) → do
     (unformatInterval str) `shouldEqual` (Left $ err)

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -6,10 +6,10 @@ import Test.Interval (intervalTest)
 import Test.DateTime (datetimeTest)
 import Test.Number (numberTest)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Control.Monad.Eff (Eff)
-import Test.Spec.Runner (RunnerEffects, run)
+import Effect (Effect)
+import Test.Spec.Runner (run)
 
-main ∷ Eff (RunnerEffects ()) Unit
+main ∷ Effect Unit
 main = run [consoleReporter] do
   intervalTest
   datetimeTest

--- a/test/src/Number.purs
+++ b/test/src/Number.purs
@@ -9,7 +9,7 @@ import Test.Spec (describe, Spec)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Utils (forAll)
 
-numberTest ∷ ∀ e. Spec e Unit
+numberTest ∷ Spec Unit
 numberTest = describe "Data.Formatter.Number" do
   forAll _.str
     "should print formatter"

--- a/test/src/Utils.purs
+++ b/test/src/Utils.purs
@@ -4,7 +4,7 @@ import Prelude
 
 
 import Test.Spec (describe, it, Spec)
-import Control.Monad.Aff (Aff)
+import Effect.Aff (Aff)
 
 import Data.Foldable (class Foldable, for_)
 import Data.Enum (toEnum)
@@ -14,7 +14,7 @@ import Data.Date (canonicalDate)
 import Data.Time (Time(..))
 
 
-forAll ∷ ∀ e a f. Foldable f ⇒ (a → String) → String → f a → (a → Aff e Unit) → Spec e Unit
+forAll ∷ ∀ a f. Foldable f ⇒ (a → String) → String → f a → (a → Aff Unit) → Spec Unit
 forAll itTitle title arb f = describe title do
   for_ arb \a → it (itTitle a) (f a)
 


### PR DESCRIPTION
Hey folks -- this PR is an extension of the version bump that @justinwoo has already provided. If it isn't adding enough on top I'm perfectly fine closing this in favor of his PR.

This PR passes the test suite.

Specifically this PR introduces:
- `toCharArray` and `fromCharArray` are now from `Data.String.CodeUnits` instead of `Data.String`. There has been discussion about when to use code units vs. code points and that may be worth considering before merging.
- 0.12 changes like renaming `id` to `identity` and removing effect rows
- I trimmed down the Bower dependencies to the core libraries used and which already bring in the rest of the transitive dependencies. However, if you'd rather be more explicit, I can re-introduce imports like `transformers`

However, this is not yet ready to merge: it's waiting on `purescript-parsing` but is proven to work using the open PR in that repository from @joncfoo. Once that is merged or similar action is taken this can be merged in as well.